### PR TITLE
Clarify documentation for autosave option

### DIFF
--- a/snapraid.d
+++ b/snapraid.d
@@ -1032,7 +1032,7 @@ Configuration
 	any wasted space.
 
   autosave SIZE_IN_GIGABYTES
-	Automatically save the state when syncing after the specified amount
+	Automatically save the state when syncing or scrubbing after the specified amount
 	of GB processed.
 	This option is useful to avoid to restart from scratch long "sync"
 	commands interrupted by a machine crash, or any other event that


### PR DESCRIPTION
According to [scrub.c](https://github.com/amadvance/snapraid/blob/master/cmdline/scrub.c#L456), autosave is also used while scrubbing. I tested it with 8.1 and autosave does also apply to scrubbing (as intended, I guess).

This updates the documentation to reflect that.