### PR TITLE
Respect sysconfdir for configuration file location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 bin_PROGRAMS = snapraid
 check_PROGRAMS = mktest mkstream
 
+AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\"
+
 snapraid_SOURCES = \
 	raid/raid.c \
 	raid/check.c \

--- a/cmdline/snapraid.c
+++ b/cmdline/snapraid.c
@@ -241,7 +241,7 @@ void config(char* conf, size_t conf_size, const char* argv0)
 #else
 	(void)argv0;
 
-	pathcpy(conf, conf_size, "/etc/" PACKAGE ".conf");
+	pathcpy(conf, conf_size, SYSCONFDIR "/" PACKAGE ".conf");
 #endif
 }
 


### PR DESCRIPTION
I use SnapRAID on FreeBSD and it works great, but the configuration file location is an anomaly. Everything else ends up in `/usr/local` as expected (e.g. `/usr/local/bin/snapraid`), but the configuration file is loaded from `/etc/` instead of `/usr/local/etc`. This patch changes it so that SnapRAID's behaviour matches what is described by `./configure --help` - that the configuration file location will be `$prefix/etc`.

Also: I have no idea what I'm doing, I pieced this together with the autoconf manuals and a lot of searching on StackOverflow. Please consider this a feature request as much as a pull request! :)

P.S. I love SnapRAID, thanks for all the work you put into this project!