### PR TITLE
fix scanning of devices with multiple slaves

### DIFF
--- a/cmdline/unix.c
+++ b/cmdline/unix.c
@@ -917,18 +917,20 @@ static int devtree(const char* name, const char* custom, dev_t device, devinfo_t
 
 		while ((dd = readdir(d)) != 0) {
 			if (dd->d_name[0] != '.') {
+				dev_t	subdev;
+
 				/* for each slave, expand the full potential tree */
 				pathprint(path, sizeof(path), "/sys/dev/block/%u:%u/slaves/%s/dev", major(device), minor(device), dd->d_name);
 
-				device = devread(path);
-				if (!device) {
+				subdev = devread(path);
+				if (!subdev) {
 					/* LCOV_EXCL_START */
 					closedir(d);
 					return -1;
 					/* LCOV_EXCL_STOP */
 				}
 
-				if (devtree(name, custom, device, parent, list) != 0) {
+				if (devtree(name, custom, subdev, parent, list) != 0) {
 					/* LCOV_EXCL_START */
 					closedir(d);
 					return -1;


### PR DESCRIPTION
The patch fixes `snapraid smart` if an LV spans more than one PV on Linux.

Full story:

`snapraid smart` suddenly stopped working after extending an LV over a second PVs.  Error from the log:

    resolve:sys:253:45:/dev/dm-45: found
    resolve:sys:8:192:/dev/sdm: found
    msg:fatal: Failed to open '/sys/dev/block/8:192/slaves/sdn/dev'.
    msg:fatal: Failed to expand device '253:45'.
    msg:fatal: Smart is unsupported in this platform.

The interesting part here is `/sys/dev/block/8:192/slaves/`.  SnapRAID scans the slaves of `dm-45` which has `sdm` and `sdn` as slaves.  However it looks below the first slave `sdm` for the second slave `sdn` of `dm-45`.

Luckily it is easy to fix that glitch.  Now slave scanning tries to access the slaves below the parent, not the last scanned slave.

After that, `snapraid smart` worked again as before.

HTH and thank you very much for SnapRAID, and a happy new Year ;)
PS: I know how to be careful when combining devices this way.
  