### PR TITLE
allow speed-test (-T) for other than 8 disks

### DIFF
--- a/cmdline/snapraid.c
+++ b/cmdline/snapraid.c
@@ -923,7 +923,7 @@ int main(int argc, char* argv[])
 	crc32c_init();
 
 	if (speedtest != 0) {
-		speed(period);
+		speed(period, plan);
 		os_done();
 		exit(EXIT_SUCCESS);
 	}

--- a/cmdline/snapraid.h
+++ b/cmdline/snapraid.h
@@ -21,7 +21,7 @@
 /****************************************************************************/
 /* snapraid */
 
-void speed(int period);
+void speed(int period, int cnt);
 void selftest(void);
 
 #endif

--- a/cmdline/speed.c
+++ b/cmdline/speed.c
@@ -75,7 +75,7 @@ static int64_t diffgettimeofday(struct timeval *start, struct timeval *stop)
  */
 static unsigned side_effect;
 
-void speed(int period)
+void speed(int period, int cnt)
 {
 	struct timeval start;
 	struct timeval stop;
@@ -89,7 +89,7 @@ void speed(int period)
 	int count;
 	int delta = period >= 1000 ? 10 : 1;
 	int size = TEST_SIZE;
-	int nd = TEST_COUNT;
+	int nd = cnt>0 ? cnt : TEST_COUNT;
 	int nv;
 	void *v_alloc;
 	void **v;


### PR DESCRIPTION
The undocumented option -T (aka --speed-test) already has an
undocumented option to run a shorter test: --test-skip-device

In a similar fashion, option -pX or --plan X now affects the
number of disks taken in account for the speed test.
As before the default is 8.