### PR TITLE
Added feature to limit disk IO bandwidth 

### DIFF
--- a/cmdline/fnmatch.h
+++ b/cmdline/fnmatch.h
@@ -47,6 +47,8 @@ extern "C" {
 #undef	FNM_PATHNAME
 #undef	FNM_NOESCAPE
 #undef	FNM_PERIOD
+#undef	FNM_LEADING_DIR	/* macOS defines these in fnmatch.h */
+#undef	FNM_CASEFOLD	/* macOS defines these in fnmatch.h */
 
 /* Bits set in the FLAGS argument to `fnmatch'.  */
 #define	FNM_PATHNAME	(1 << 0) /* No wildcard can ever match `/'.  */

--- a/cmdline/handle.h
+++ b/cmdline/handle.h
@@ -33,6 +33,7 @@ struct snapraid_handle {
 	struct advise_struct advise; /**< Advise information. */
 	data_off_t valid_size; /**< Size of the valid data. */
 	int created; /**< If the file was created, otherwise it was already existing. */
+	struct snapraid_io* io; /**< IO context for bandwidth limiting. */
 };
 
 /**

--- a/cmdline/io.h
+++ b/cmdline/io.h
@@ -192,6 +192,13 @@ struct snapraid_io {
 #endif
 
 	/**
+	 * Bandwidth limiting
+	 */
+	uint64_t bwlimit;           /**< Bandwidth limit in bytes per second */
+	uint64_t bwlimit_remaining; /**< Remaining bytes allowed in current second */
+	time_t bwlimit_reset;       /**< Time when to reset the bandwidth counter */
+
+	/**
 	 * Base position for workers.
 	 *
 	 * It's the index in the ::worker_map[].
@@ -303,6 +310,13 @@ void io_init(struct snapraid_io* io, struct snapraid_state* state,
 	void (*parity_reader)(struct snapraid_worker*, struct snapraid_task*),
 	void (*parity_writer)(struct snapraid_worker*, struct snapraid_task*),
 	struct snapraid_parity_handle* parity_handle_map, unsigned parity_handle_max);
+
+/**
+ * Limit IO bandwidth to stay within the configured limit.
+ * If no limit is set, returns immediately.
+ * Otherwise sleeps as needed to maintain the rate limit.
+ */
+void io_limit_bandwidth(struct snapraid_io* io, size_t bytes);
 
 /**
  * Deinitialize the InputOutput workers.

--- a/cmdline/parity.h
+++ b/cmdline/parity.h
@@ -57,6 +57,7 @@ struct snapraid_parity_handle {
 	struct snapraid_split_handle split_map[SPLIT_MAX];
 	unsigned split_mac; /**< Number of parity splits. */
 	unsigned level; /**< Level of the parity. */
+	struct snapraid_io* io; /**< IO context for bandwidth limiting. */
 };
 
 /**

--- a/cmdline/snapraid.c
+++ b/cmdline/snapraid.c
@@ -74,6 +74,7 @@ void usage(void)
 	printf("  " SWITCH_GETOPT_LONG("-N, --force-nocopy    ", "-N") "  Force commands disabling the copy detection\n");
 	printf("  " SWITCH_GETOPT_LONG("-F, --force-full      ", "-F") "  Force a full parity computation in sync\n");
 	printf("  " SWITCH_GETOPT_LONG("-R, --force-realloc   ", "-R") "  Force a full parity reallocation in sync\n");
+	printf("  " SWITCH_GETOPT_LONG("-w, --bwlimit RATE    ", "-w") "  Limit IO bandwidth (M|G)\n");
 	printf("  " SWITCH_GETOPT_LONG("-v, --verbose         ", "-v") "  Verbose\n");
 }
 
@@ -333,6 +334,7 @@ struct option long_options[] = {
 	{ "force-nocopy", 0, 0, 'N' },
 	{ "force-full", 0, 0, 'F' },
 	{ "force-realloc", 0, 0, 'R' },
+	{ "bwlimit", 1, 0, 'w' },
 	{ "audit-only", 0, 0, 'a' },
 	{ "pre-hash", 0, 0, 'h' },
 	{ "speed-test", 0, 0, 'T' }, /* undocumented speed test command */
@@ -484,7 +486,7 @@ struct option long_options[] = {
 };
 #endif
 
-#define OPTIONS "c:f:d:mebp:o:S:B:L:i:l:ZEUDNFRahTC:vqHVG"
+#define OPTIONS "c:f:d:mebp:o:S:B:L:i:l:ZEUDNFRahTC:vqHVGw:"
 
 volatile int global_interrupt = 0;
 
@@ -669,6 +671,37 @@ int main(int argc, char* argv[])
 			if (!e || *e || olderthan > 1000) {
 				/* LCOV_EXCL_START */
 				log_fatal("Invalid number of days '%s'\n", optarg);
+				exit(EXIT_FAILURE);
+				/* LCOV_EXCL_STOP */
+			}
+			break;
+		case 'w' : /* --bwlimit */
+			if (optarg == 0) {
+				/* LCOV_EXCL_START */
+				log_fatal("Missing bandwidth limit\n");
+				exit(EXIT_FAILURE);
+				/* LCOV_EXCL_STOP */
+			}
+
+			/* Parse the number part */
+			opt.bwlimit = strtoul(optarg, &e, 10);
+			if (!e || e == optarg) {
+				/* LCOV_EXCL_START */
+				log_fatal("Invalid bandwidth limit '%s'\n", optarg);
+				exit(EXIT_FAILURE);
+				/* LCOV_EXCL_STOP */
+			}
+
+			/* Handle suffixes */
+			if (e[0] == 'k' || e[0] == 'K') {
+				opt.bwlimit *= 1024;
+			} else if (e[0] == 'm' || e[0] == 'M') {
+				opt.bwlimit *= 1024 * 1024;
+			} else if (e[0] == 'g' || e[0] == 'G') {
+				opt.bwlimit *= 1024 * 1024 * 1024;
+			} else if (e[0] != '\0') {
+				/* LCOV_EXCL_START */
+				log_fatal("Invalid bandwidth limit suffix '%s'\n", e);
 				exit(EXIT_FAILURE);
 				/* LCOV_EXCL_STOP */
 			}
@@ -1336,6 +1369,7 @@ int main(int argc, char* argv[])
 		/*   but without saving the content file representing this new EMPTY state. */
 		/* - Another file is added again over the DELETE ones */
 		/*   with the hash of DELETED blocks not representing the real parity state */
+
 		state.clear_past_hash = 1;
 
 		state_read(&state);
@@ -1543,4 +1577,3 @@ int main(int argc, char* argv[])
 
 	return EXIT_SUCCESS;
 }
-

--- a/cmdline/state.h
+++ b/cmdline/state.h
@@ -120,6 +120,7 @@ struct snapraid_option {
 	int force_stats; /**< Force stats print during process. */
 	uint64_t parity_limit_size; /**< Test limit for parity files. */
 	int skip_multi_scan; /**< Don't use threads in scan. */
+	uint64_t bwlimit; /**< Bandwidth limit in bytes per second. */
 };
 
 struct snapraid_state {


### PR DESCRIPTION
This PR adds a new `--bwlimit` flag to limit IO bandwidth across all active drives during SnapRAID operations. The bandwidth limit is applied globally and dynamically redistributed among active drives as operations complete.
 
Example Usage 
```
# Limit total disk IO bandwidth to 100MB/s on a sync
snapraid --bwlimit 100M sync

#Limit total disk IO bandwidth to 1GB/s during scrubbing
snapraid --bwlimit 1G scrub

#Limit total disk IO bandwidth to 200MB/s during file recovery
snapraid --bwlimit 200M fix
```

Implementation details
* Tested on Linux, MacOS, and Windows
* Handles both read and write operations
* Gracefully handles operation completion and bandwidth redistribution