### PR TITLE
Add structured log output for status command to enable ASCII-free parsing

### DIFF
--- a/cmdline/status.c
+++ b/cmdline/status.c
@@ -431,7 +431,7 @@ int state_status(struct snapraid_state* state)
 		unsigned both = bar_scrubbed[i] + bar_new[i];
 		unsigned percentage = muldiv(both, 100, count);
 		unsigned range = dayoldest - daynewest;
-		unsigned days_ago = i * range / (GRAPH_COLUMN - 1);
+		unsigned days_ago = dayoldest - i * range / (GRAPH_COLUMN - 1);
 		log_tag("scrub_history:%u:%u\n", days_ago, percentage);
 	}
 


### PR DESCRIPTION
**Add structured log output for status command to enable ASCII-free parsing**

In the process of migrating to a "structured"  (key/value) parser, i noticed some fields are missing.

Could I try to add those missing fields? Command for Command, with small PR's. Because i want to get rid of the ASCI parsing all at once.

This PR enhances the structured log output of the `snapraid status` command by adding new `log_tag()` calls in status.c. The goal is to provide all necessary key:value pairs for parsing the status output without relying on ASCII table parsing.

#### Changes Made:
1. **Disk Table Structured Data**:
   - Added `summary:disk_used:<disk>:<value>` (used space in bytes)
   - Added `summary:disk_free:<disk>:<value>` (free space in bytes)
   - Added `summary:disk_use_percent:<disk>:<value>` (usage percentage)
   - These are calculated from existing block counts and block size, matching the ASCII table values.

2. **Scrub History Structured Data**:
   - Added `scrub_history:<days_ago>:<percentage>` for each point in the scrub history graph.
   - Replaces the need to parse the ASCII art histogram by providing direct percentage values per day.
   - scrub history is also based on 70 Bins (GRAPH_COLUMN) like the ASCI histrogram, even if i don't fully understand this and why its not aggregated by day. But this way its consistent with the ASCI.

3. **Scrub Age Structured Data**:
   - Added `summary:scrub_oldest_days:<value>`
   - Added `summary:scrub_median_days:<value>`
   - Added `summary:scrub_newest_days:<value>`
   - Eliminates the need to parse the text "The oldest block was scrubbed X days ago, the median Y, the newest Z."

4. **Totals Structured Data**:
   - Added `summary:total_wasted:<value>`
   - Added `summary:total_used:<value>`
   - Added `summary:total_free:<value>`
   - Added `summary:total_use_percent:<value>`
   - Provides direct access to the total values from the summary line without ASCII parsing.
